### PR TITLE
Replace sym(0) by 0

### DIFF
--- a/w3j.m
+++ b/w3j.m
@@ -33,7 +33,7 @@ else
         factorial(j1 + j2 + j3 + 1);
     
     % summation over integers that do not result in negative factorials
-    Sum_t = sym(0);
+    Sum_t = 0;
     for t = 0:N_t
         
         % check factorial for negative values, include in sum if not

--- a/w3j_stirling.m
+++ b/w3j_stirling.m
@@ -39,7 +39,7 @@ else
         logf(-j1 + j2 + j3) - logf(j1 + j2 + j3 + 1)));
     
     % summation over integers that do not result in negative factorials
-    Sum_t = sym(0);
+    Sum_t = 0;
     for t = 0:N_t
         
         % check factorial for negative values, include in sum if not


### PR DESCRIPTION
Avoid requiring symbolic math toolbox when not necessary.
Both functions return evaluated form.